### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/slandath/poke-battle/security/code-scanning/1](https://github.com/slandath/poke-battle/security/code-scanning/1)

To fix the problem, explicitly declare the minimal required `GITHUB_TOKEN` permissions in the workflow. Since this lint job only checks out the repository and runs local tooling, it only needs read access to repository contents. Adding a `permissions` block at the workflow root will apply to all jobs in this workflow and constrain the token.

The best minimal change is to add:

```yaml
permissions:
  contents: read
```

near the top of `.github/workflows/lint.yml`, alongside `name` and `on`. This does not alter the job steps or behavior; it only restricts the implicit token permissions. No additional imports, methods, or definitions are required, as this is purely a YAML configuration change to the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration with explicit read permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->